### PR TITLE
Misc fixes

### DIFF
--- a/source/earthbound/bank00.d
+++ b/source/earthbound/bank00.d
@@ -4435,6 +4435,7 @@ void IRQNMICommon() {
 	WH2 = UNUSED_WH2_MIRROR;
 	for (short i = Unknown7E0001; i != DMAQueueIndex; i++) {
 		DMAChannels[0].DMAP = DMATable[DMAQueue[i].mode].unknown0;
+		DMAChannels[0].BBAD = DMATable[DMAQueue[i].mode].unknown1;
 		VMAIN = DMATable[DMAQueue[i].mode].unknown2;
 		DMAChannels[0].DAS = DMAQueue[i].size;
 		DMAChannels[0].A1T = DMAQueue[i].source;
@@ -4483,7 +4484,7 @@ void IRQNMICommon() {
 		}
 	}
 	NextFrameDisplayID = 0;
-	if ((INIDISP_MIRROR & 0x80) != 0) {
+	if ((INIDISP_MIRROR & 0x80) == 0) {
 		TM = TM_MIRROR;
 		TD = TD_MIRROR;
 		HDMAEN = HDMAEN_MIRROR;
@@ -4813,7 +4814,7 @@ void FadeInWithMosaic(short arg1, short arg2, short arg3) {
 	INIDISP_MIRROR = 0;
 	while(true) {
 		MOSAIC_MIRROR = 0;
-		if (INIDISP_MIRROR + arg1 >= 0x15) {
+		if (INIDISP_MIRROR + arg1 >= 0x0F) {
 			break;
 		}
 		SetINIDISP(cast(ubyte)(INIDISP_MIRROR + arg1));
@@ -5317,7 +5318,7 @@ short InitEntity(short actionScript, short x, short y) {
 	EntityDeltaYTable[newEntity / 2] = 0;
 	EntityDeltaZFractionTable[newEntity / 2] = 0;
 	EntityDeltaZTable[newEntity / 2] = 0;
-	return UnknownC092F5Unknown4(&EventScriptPointers[EntityScriptTable[actionScript]][0], newEntity);
+	return UnknownC092F5Unknown4(&EventScriptPointers[actionScript][0], newEntity);
 }
 
 short InitEntityUnknown1(const(ubyte)* pc, short entityID) {
@@ -7678,17 +7679,17 @@ void DoBackgroundDMA(short arg1, short arg2, short arg3) {
 	if (arg3 == 0) {
 		short x = 6;
 		do {
+			// The original game code does 16-bit copy here, which copies
+			// one byte too many. Do one byte at a time instead.
 			Unknown7E3C32[x] = UnknownC0AE26[x];
-			Unknown7E3C32[x + 1] = UnknownC0AE26[x + 1];
-			x -= 2;
+			x -= 1;
 		} while (x >= 0);
 		a = &Unknown7E3C32[0];
 	} else {
 		short x = 6;
 		do {
 			Unknown7E3C3C[x] = UnknownC0AE2D[x];
-			Unknown7E3C3C[x + 1] = UnknownC0AE2D[x + 1];
-			x -= 2;
+			x -= 1;
 		} while (x >= 0);
 		a = &Unknown7E3C3C[0];
 	}
@@ -7779,7 +7780,7 @@ void PrepareBackgroundOffsetTables(short arg1, short arg2, short arg3) {
 		do {
 			Unknown7E3C46[y / 2] = cast(ushort)(((arg2 * SineLookupTable[x03]) >> 8) + x05);
 			x02 += x00;
-			y -= 2;
+			y += 2;
 		} while (y < x09);
 		return;
 	} else {
@@ -7789,7 +7790,7 @@ void PrepareBackgroundOffsetTables(short arg1, short arg2, short arg3) {
 			x02 += x00;
 			Unknown7E3C46[y / 2 + 1] = cast(ushort)(x05 - ((arg2 * SineLookupTable[x03]) >> 8));
 			x02 += x00;
-			y -= 4;
+			y += 4;
 		} while (y < x09);
 		return;
 	}
@@ -7819,7 +7820,7 @@ void PrepareBackgroundOffsetTables(short arg1, short arg2, short arg3) {
 		x05 += Unknown7E1AD4;
 		Unknown7E3C46[y / 2] = cast(ushort)((cast(ushort)x05 >> 8) + ((arg2 * SineLookupTable[x03]) >> 8));
 		x02 += x00;
-		y -= 2;
+		y += 2;
 	} while (y < x09);
 	return;
 	Unknown10:
@@ -7850,7 +7851,7 @@ void PrepareBackgroundOffsetTables(short arg1, short arg2, short arg3) {
 		x05 += Unknown7E1AD4;
 		Unknown7E3C46[y / 2 + 1] = cast(ushort)((cast(ushort)x05 >> 8) - ((arg2 * SineLookupTable[x03]) >> 8));
 		x02 += x00;
-		y -= 4;
+		y += 4;
 	} while (y < x09);
 	return;
 }
@@ -8062,7 +8063,7 @@ void FileSelectInit() {
 	OverworldSetupVRAM();
 	UnknownC432B1();
 	UnknownC005E7();
-	memcpy(&palettes[16][0], SpriteGroupPalettes.ptr, 0x100);
+	memcpy(&palettes[8][0], SpriteGroupPalettes.ptr, 0x100);
 	UnknownC200D9();
 	CopyToVram(3, 0x800, 0x7C00, Unknown7F0000.ptr);
 	Decomp(TextWindowGraphics.ptr, Unknown7F0000.ptr);

--- a/source/earthbound/bank02.d
+++ b/source/earthbound/bank02.d
@@ -6910,6 +6910,7 @@ void GenerateBattleBGFrame(LoadedBackgroundData* arg1, short layer) {
 	short x19 = arg1.TargetLayer;
 	if (arg1.Unknown2 == 0) {
 		if ((arg1.PaletteChangeDurationLeft != 0) && (--arg1.PaletteChangeDurationLeft == 0)) {
+			arg1.PaletteChangeDurationLeft = arg1.PaletteChangeSpeed;
 			switch (arg1.PaletteShiftingStyle) {
 				case 2:
 					short x02 = cast(short)(arg1.PaletteCycle2Last - arg1.PaletteCycle2First + 1);
@@ -6922,7 +6923,7 @@ void GenerateBattleBGFrame(LoadedBackgroundData* arg1, short layer) {
 						}
 						arg1.PalettePointer[0][arg1.PaletteCycle2First + i] = arg1.Palette[arg1.PaletteCycle2First + x14];
 					}
-					if (++arg1.PaletteCycle2Step < x02) {
+					if (++arg1.PaletteCycle2Step >= x02) {
 						arg1.PaletteCycle2Step = 0;
 					}
 					goto case;
@@ -6937,7 +6938,7 @@ void GenerateBattleBGFrame(LoadedBackgroundData* arg1, short layer) {
 						}
 						arg1.PalettePointer[0][arg1.PaletteCycle1First + i] = arg1.Palette[arg1.PaletteCycle1First + x14];
 					}
-					if (++arg1.PaletteCycle1Step < x02) {
+					if (++arg1.PaletteCycle1Step >= x02) {
 						arg1.PaletteCycle1Step = 0;
 					}
 					break;

--- a/source/earthbound/bank04.d
+++ b/source/earthbound/bank04.d
@@ -3841,8 +3841,8 @@ void UnknownC4954C(short arg1, ushort* arg2) {
 void UnknownC4958E(short arg1, short arg2, ushort* arg3) {
 	ushort* x06 = cast(ushort*)&Unknown7F0000[0];
 	memset(&Unknown7F0000[0x200], 0, 0x1000);
-	for (ubyte i = 0; i < 0x100; i += 16) {
-		for (ubyte j = i; i + 16 > j; j++) {
+	for (ushort i = 0; i < 0x100; i += 16) {
+		for (ushort j = i; i + 16 > j; j++) {
 			ubyte x02;
 			if ((arg2 & 1) != 0) {
 				x02 = x06[j] & 0xFF;
@@ -6480,7 +6480,7 @@ void LoadTownMapData(short arg1) {
 	Decomp(&TownMapGraphicsPointerTable[arg1][0], &Unknown7F0000[0]);
 	while (Unknown7E0028.a != 0) {}
 	memcpy(&palettes[0][0], &Unknown7F0000[0], 0x40);
-	memcpy(&palettes[16][0], &TownMapIconPalette[0], 0x100);
+	memcpy(&palettes[8][0], &TownMapIconPalette[0], 0x100);
 	SetBG1VRAMLocation(BGTileMapSize.normal, 0x3000, 0);
 	SetOAMSize(3);
 	CGADSUB = 0;

--- a/source/earthbound/globals.d
+++ b/source/earthbound/globals.d
@@ -129,7 +129,7 @@ __gshared ubyte Unknown7E00D1;
 __gshared ubyte Unknown7E00D2;
 __gshared short Unknown7E00D3;
 
-__gshared ushort[16][32] palettes; /// $0200
+__gshared ushort[16][16] palettes; /// $0200
 __gshared DMAQueueEntry[30] DMAQueue; /// $0400
 
 auto ref CurrentTextPalette() { return palettes[0]; }
@@ -366,9 +366,9 @@ __gshared short Unknown7E3C2A; /// $3C2A
 __gshared short Unknown7E3C2C; /// $3C2C
 __gshared short Unknown7E3C2E; /// $3C2E
 __gshared short Unknown7E3C30; /// $3C30
-__gshared ubyte[6] Unknown7E3C32; /// $3C32
+__gshared ubyte[7] Unknown7E3C32; /// $3C32
 
-__gshared ubyte[6] Unknown7E3C3C; /// $3C3C
+__gshared ubyte[7] Unknown7E3C3C; /// $3C3C
 
 __gshared ushort[448] Unknown7E3C46; /// $3C46
 __gshared HDMATableEntry[3] Unknown7E3FC6; /// $3FC6


### PR DESCRIPTION
# Bank 00
## IRQNMICommon:
- Set B bus address during DMA (missed 2nd part of 16-bit write)
- Fix INIDISP_MIRROR comparison

## FadeInWithMosaic:
- Fix accidental 0x15 to 0x0F

## InitEntity:
- Remove erroneous array indexing

## DoBackgroundDMA:
- The original game does a 16-bit copy when it only wants 7 bytes of data and ends up writing one too many bytes, so we do an 8-bit copy instead

## PrepareBackgroundOffsetTables:
- Fix `y -= ...` to `y += ...`

## FileSelectInit:
- Fix palette indexing (8 BG palettes, then 8 Obj palettes)

# Bank 02
## GenerateBattleBGFrame:
- Add resetting of PaletteChangeDurationLeft
- Fix PaletteCycleStep comparison

# Bank 04
## UnknownC4958E:
- Change i, j from `ubyte` to `ushort` to prevent overflow

## LoadTownMapData:
- Fix palette indexing

# Globals
- Fix palette length from 32 to 16
- Fix length of Unknown7E3C32 and Unknown7E3C3C