### PR TITLE
Fix issue with tile deallocation in CloseWindow

### DIFF
--- a/source/earthbound/bank03.d
+++ b/source/earthbound/bank03.d
@@ -385,9 +385,11 @@ void CloseWindow(short arg1) {
 	ushort* x0E = &bg2Buffer[WindowStats[x10].y * 32 + WindowStats[x10].x];
 	ushort* x14_2 = WindowStats[x10].tilemapBuffer;
 	for (short i = 0; i < WindowStats[x10].width * WindowStats[x10].height; i++) {
-		if ((x14_2[0] == 0x40) || (x14_2[0] == 0)) {
+		// Wack vanilla code.. the body of this if statement always runs
+		/+ if ((x14_2[0] != 0x40) || (x14_2[0] != 0)) { +/
+			// Deallocate VWF tiles
 			UnknownC44AF7(x14_2[0]);
-		}
+		/+ } +/
 		x14_2[0] = 0x40;
 		x14_2++;
 	}


### PR DESCRIPTION
The original code definitely has an error here:
```
	LDA a:.LOWORD(RAM),Y
	CMP #$0040
	BNE @UNKNOWN8
	CMP #$0000
	BEQ @UNKNOWN9
@UNKNOWN8:
	LDA a:.LOWORD(RAM),Y
	JSL UNKNOWN_C44AF7
@UNKNOWN9:
```
The only way the code at Unk8 is skipped is if A is both 0 and 0x40... I think they meant to skip if A is 0 __or__ 0x40...