### PR TITLE
Use separate variable for tile arrangement buffer (instead of unknown7F0000 + 0x8000)

### DIFF
--- a/source/earthbound/bank00.d
+++ b/source/earthbound/bank00.d
@@ -122,7 +122,7 @@ void animatePalette() {
 
 /// $C0035B
 ushort unknownC0035B(ushort a, ushort x, ushort y) {
-	return unknown7F0000[0x8000 + a * 32 + x * 2 + y * 8];
+	return tileArrangementBuffer[a * 16 + x + y * 4];
 }
 
 /// $C00391
@@ -213,8 +213,8 @@ void loadCollisionData(short tileset) {
 
 /// $C0067E
 void function14(short index1, short index2) {
-	ushort* x0A = cast(ushort*)&unknown7F0000[0x8000 + index1 * 32];
-	ushort* x06 = cast(ushort*)&unknown7F0000[0x8000 + index2 * 32];
+	ushort* x0A = &tileArrangementBuffer[index1 * 16];
+	ushort* x06 = &tileArrangementBuffer[index2 * 16];
 	for (short i = 0; i < 16; i++) {
 		*(x0A++) = *(x06++);
 	}
@@ -285,7 +285,7 @@ void loadMapAtSector(short x, short y) {
 	ubyte x18 = x1A & 7;
 	ubyte x04 = x1A >> 3;
 	tracef("Loading map tileset %d, palette %d", x04, x18);
-	decomp(&mapDataTileArrangementPtrTable[tilesetTable[x04]][0], &unknown7F0000[0x8000]);
+	decomp(&mapDataTileArrangementPtrTable[tilesetTable[x04]][0], &tileArrangementBuffer[0]);
 	loadCollisionData(tilesetTable[x04]);
 	unknownC006F2(tilesetTable[x04]);
 	unknownC005E7();
@@ -462,7 +462,7 @@ void unknownC00E16(short x, short y) {
 		if ((x & 3) == 0) {
 			x18 = cast(ushort)((unknown7EF000.unknown7EF000[((y / 4) & 0xF)][(x / 4) & 0xF] * 16) + ((y & 3) * 4));
 		}
-		ushort x12 = (cast(ushort*)&unknown7F0000)[0x8000 + x18];
+		ushort x12 = tileArrangementBuffer[x18];
 		x1E[x16] = x12;
 		x18++;
 		if ((x12 & 0x3FF) < 0x180) {
@@ -496,7 +496,7 @@ void unknownC00FCB(short x, short y) {
 		if ((y & 3) == 0) {
 			x18 = cast(ushort)((unknown7EF000.unknown7EF000[((y / 4) & 0xF)][(x / 4) & 0xF] * 16) + (x & 3));
 		}
-		ushort x12 = (cast(ushort*)&unknown7F0000)[0x8000 + x18];
+		ushort x12 = tileArrangementBuffer[x18];
 		x1E[x16] = x12;
 		if ((x12 & 0x3FF) < 0x180) {
 			x12 |= 0x2000;

--- a/source/earthbound/bank04.d
+++ b/source/earthbound/bank04.d
@@ -6831,8 +6831,8 @@ void prepareYourSanctuaryLocationTileArrangementData(short arg1, short arg2, sho
 			} else {
 				x0F = 0;
 			}
-			unknown7EF000.unknown7EF000Alt[unknown7F0000[0x8000 + (((i + arg2) & 3) * 4) + (x0F * 16) + (j + arg1) & 3] & 0x3FF * 2] = 0xFFFF;
-			(x06++)[0] = unknown7F0000[0x8000 + (((i + arg2) & 3) * 4) + (x0F * 16) + (j + arg1) & 3];
+			unknown7EF000.unknown7EF000Alt[tileArrangementBuffer[(((i + arg2) & 3) * 4) + (x0F * 16) + (j + arg1) & 3] & 0x3FF * 2] = 0xFFFF;
+			(x06++)[0] = tileArrangementBuffer[(((i + arg2) & 3) * 4) + (x0F * 16) + (j + arg1) & 3];
 		}
 	}
 }
@@ -6843,7 +6843,7 @@ void prepareYourSanctuaryLocationTilesetData(short arg1) {
 		if (unknown7EF000.unknown7EF000Alt[i] == 0) {
 			continue;
 		}
-		copyToVRAM(0, 0x20, (unknown7EB4B8 * 16 + 0x6000) & 0x7FFF, &unknown7F0000[0x8000 + i * 32]);
+		copyToVRAM(0, 0x20, (unknown7EB4B8 * 16 + 0x6000) & 0x7FFF, cast(ubyte*)&tileArrangementBuffer[i * 16]);
 		unknown7EF000.unknown7EF000Alt[i] = unknown7EB4B8;
 		unknown7EB4B8++;
 		yourSanctuaryLoadedTilesetTiles++;

--- a/source/earthbound/globals.d
+++ b/source/earthbound/globals.d
@@ -915,6 +915,7 @@ __gshared ubyte[0x2000] unknown7EC000; /// $C000
 __gshared ubyte[64][64] unknown7EE000; /// $E000
 __gshared Unknown7EF000Stuff unknown7EF000; /// $F000
 __gshared ubyte[0x10000] unknown7F0000; /// $7F0000
+__gshared ushort[0x3C00] tileArrangementBuffer; /// $7F8000
 __gshared const(ubyte[4][4])*[0x400] tileCollisionBuffer; /// $7FF800
 
 __gshared ubyte[0x8000] introBG2Buffer; /// $8000 - this seems to overlap with other stuff...?


### PR DESCRIPTION
This fixes a bunch of wrong indexing due to byte vs. word size