### PR TITLE
More fixes

### DIFF
--- a/sdl/source/sfcdma.d
+++ b/sdl/source/sfcdma.d
@@ -47,6 +47,18 @@ void handleDma() {
                 transferSize = 1;
                 dstAdjust = 1; // skip byte when copying
             }
+            // Handle VMAIN
+            auto addrIncrementAmount = [1, 32, 128, 256][VMAIN & 0x03];
+            // Skip ahead by addrIncrementAmount words, less the word we just
+            // dealt with by setting transferSize and dstAdjust.
+            dstAdjust += (addrIncrementAmount - 1) * 2;
+            // Address mapping is not implemented.
+            assert((VMAIN & 0x0C) == 0);
+            // Address increment is only supported for the used cases:
+            // - writing word value and increment after writing $2119
+            // - writing byte to $2119 and increment after writing $2119
+            // - writing byte to $2118 and increment after writing $2118
+            assert((VMAIN & 0x80) || (!hibyte && transferSize == 1));
             wrapTo = cast(ubyte *)(&g_frameData.vram);
             dest = wrapTo + ((VMADDL | VMADDH << 8) << 1 + (hibyte ? 1 : 0));
             wrapAt = wrapTo + 0x10000;

--- a/source/earthbound/actionscripts.d
+++ b/source/earthbound/actionscripts.d
@@ -794,7 +794,7 @@ immutable ubyte[2 + 2 * (const(void)*).sizeof] event283;
 immutable ubyte[21 + 2 * (const(void)*).sizeof] unknownC3BED4;
 immutable ubyte[242 + 37 * (const(void)*).sizeof] event368;
 immutable ubyte[38 + 10 * (const(void)*).sizeof] event816;
-immutable ubyte[6 + 3 * (const(void)*).sizeof] event8;
+immutable ubyte[7 + 4 * (const(void)*).sizeof] event8;
 immutable ubyte[6 + 2 * (const(void)*).sizeof] unknownC3AAB8;
 immutable ubyte[20 + 5 * (const(void)*).sizeof] event825;
 immutable ubyte[23 + 6 * (const(void)*).sizeof] event142;
@@ -17007,6 +17007,7 @@ event8 = [
 	EVENT_SET_VELOCITIES_ZERO(),
 	EVENT_CALLROUTINE(&fixArgs!unknownC0C7DB),
 	EVENT_CALLROUTINE(&fixArgs!unknownC0A443MovementEntry2),
+	EVENT_SHORTJUMP(&event8Entry2[0]),
 ].join();
 unknownC3AAB8 = [
 	EVENT_SET_PHYSICS_CALLBACK(&unknownC0A37A),

--- a/source/earthbound/bank00.d
+++ b/source/earthbound/bank00.d
@@ -395,20 +395,40 @@ void unknownC00BDC(short x, short y) {
 	unknown7E43B0[x18] = cast(byte)x;
 	short x16 = y & 0xF;
 	unknown7E43C0[x16] = cast(byte)y;
-	short x14 = globalMapTilesetPaletteData[y / 4][x / 8] / 8;
-	ushort* x12 = &unknown7EF000.unknown7EF000[x18][0];
-	if (x < 0x100) {
+	ubyte x14;
+	version(bugfix) {
+		// Use a boolean to track that x14 hasn't been set yet
+		bool x14Set = false;
+	} else {
+		x14 = globalMapTilesetPaletteData[y / 4][x / 8] / 8;
+	}
+	ushort* x12 = &unknown7EF000.unknown7EF000[0][x18];
+	if (cast(ushort)x < 0x100) {
 		short x10 = cast(short)(x16 * 16);
 		for (short i = 0; i < 16; i++) {
-			if ((y & 3) == 0) {
-				x14 = globalMapTilesetPaletteData[y / 4][x / 8] / 8;
-			}
-			if ((y < 0x140) && (unknown7E436E == x14)) {
-				x12[x10] = unknownC0A156(x, y);
+			version(bugfix) {
+				// Set x14 only if coordinates are in range, and only if it needs
+				// to be set (it was never set, or beginning new sector)
+				if ((cast(ushort)y < 0x140) && (!x14Set || ((y & 3) == 0))) {
+					x14 = globalMapTilesetPaletteData[y / 4][x / 8] / 8;
+					x14Set = true;
+				}
+				if ((cast(ushort)y < 0x140) && x14Set && (unknown7E436E == x14)) {
+					x12[x10] = unknownC0A156(x, y);
+				} else {
+					x12[x10] = 0;
+				}
 			} else {
-				x12[x10] = 0;
+				if ((y & 3) == 0) {
+					x14 = globalMapTilesetPaletteData[y / 4][x / 8] / 8;
+				}
+				if ((cast(ushort)y < 0x140) && (unknown7E436E == x14)) {
+					x12[x10] = unknownC0A156(x, y);
+				} else {
+					x12[x10] = 0;
+				}
 			}
-			x10 += 16;
+			x10 = (x10 + 16) & 0xFF;
 			y++;
 		}
 	} else {
@@ -3219,7 +3239,7 @@ short npcCollisionCheck(short x, short y, short arg3) {
 			if (entityAbsXTable[i] - yReg - x18 * 2 >= x) {
 				continue;
 			}
-			if (entityAbsXTable[i] - yReg + yReg * 2 <= y) {
+			if (entityAbsXTable[i] - yReg + yReg * 2 <= x) {
 				continue;
 			}
 			result = i;


### PR DESCRIPTION
- Fix tilemap DMA when moving horizontally by implementing VMAIN support in sfcdma
- Fix entity glitchiness by making event8 fallthrough into event8Entry2
- Fix horizontal scrolling by fixing C00BDC similar to previous fix for C00AC5
- Fix npcCollisionCheck to compare right-side of hitbox against X coord instead of Y coord (fixes bad collision against entities)