### PR TITLE
Several fixes

### DIFF
--- a/source/earthbound/bank00.d
+++ b/source/earthbound/bank00.d
@@ -8336,7 +8336,7 @@ void ebMain() {
 			processQueuedInteractions();
 			inputDisableFrameCounter++;
 		} else if ((gameState.unknownB0 != 2) && (gameState.walkingStyle != WalkingStyle.escalator) && !battleSwirlCountdown) {
-			if (!battleDebug) {
+			if (battleDebug) {
 				initBattleOverworld();
 				inputDisableFrameCounter++;
 			} else if (((padPress[0] & (Pad.a | Pad.l)) != 0) || (gameState.walkingStyle == WalkingStyle.bicycle)) {
@@ -8386,7 +8386,7 @@ void ebMain() {
 				}
 			}
 		}
-		if (unknownC04FFE() && !spawn()) {
+		if (!unknownC04FFE() && spawn()) {
 			goto RestartGame;
 		}
 		if (debugging && ((padState[0] & Pad.start) != 0) && ((padState[0] & Pad.select) == 0)) {

--- a/source/earthbound/bank01.d
+++ b/source/earthbound/bank01.d
@@ -2169,7 +2169,7 @@ void openHPPPDisplay() {
 
 /// $C13CE5
 void showTownMap() {
-	if (findItemInInventory(0xFF, ItemID.townMap) == 0) {
+	if (findItemInInventory2(0xFF, ItemID.townMap) == 0) {
 		return;
 	}
 	unknownC0943C();

--- a/source/earthbound/bank02.d
+++ b/source/earthbound/bank02.d
@@ -408,7 +408,7 @@ immutable ubyte[4][2] thethe = [
 /// $C20A20
 void unknownC20A20(WindowTextAttributesCopy* buf) {
 	buf.id = currentFocusWindow;
-	if (currentFocusWindow == 0xFFFF) {
+	if (currentFocusWindow == -1) {
 		return;
 	}
 	buf.textX = windowStats[windowTable[currentFocusWindow]].textX;
@@ -420,10 +420,10 @@ void unknownC20A20(WindowTextAttributesCopy* buf) {
 
 /// $C20ABC
 void unknownC20ABC(WindowTextAttributesCopy* buf) {
-	if (buf.id == 0xFFFF) {
+	if (buf.id == -1) {
 		return;
 	}
-	if (windowTable[buf.id] == 0xFFFF) {
+	if (windowTable[buf.id] == -1) {
 		return;
 	}
 	currentFocusWindow = buf.id;

--- a/source/earthbound/bank03.d
+++ b/source/earthbound/bank03.d
@@ -329,9 +329,9 @@ immutable ubyte[4] unknownC3E44C = ebString!4("そのた"); //tx6 in EB
 void unknownC3E450() {
 	const(RGB)* x06;
 	if ((unknown7E0002 & 4) != 0) {
-		x06 = &textWindowFlavourPalettes[textWindowProperties[gameState.textFlavour].offset / 0x40][4];
+		x06 = &textWindowFlavourPalettes[textWindowProperties[gameState.textFlavour - 1].offset / 0x40][4];
 	} else {
-		x06 = &textWindowFlavourPalettes[textWindowProperties[gameState.textFlavour].offset / 0x40][20];
+		x06 = &textWindowFlavourPalettes[textWindowProperties[gameState.textFlavour - 1].offset / 0x40][20];
 	}
 	memcpy(&palettes[1][4], x06, 8);
 	unknown7E0030 = 0x18;

--- a/source/earthbound/bank04.d
+++ b/source/earthbound/bank04.d
@@ -329,29 +329,32 @@ immutable ushort[16] unknownC41FDF = [
 
 /// $C41FFF
 FixedPoint1616 unknownC41FFF(short arg1, short arg2) {
+	short arg1Modified = ((arg1 >> 8) & 0xFC) >> 1;
 	short a;
-	if (unknownC4205D[((arg1 >> 8) & 0xFC) >> 2] == 0x100) {
+	if (unknownC41FFFSineTable[arg1Modified / 2] == 0x100) {
 		a = arg2;
 	} else {
-		a = unknownC4213F(unknownC4205D[((arg1 >> 8) & 0xFC) >> 2], arg2);
+		a = unknownC4213F(unknownC41FFFSineTable[arg1Modified / 2], arg2);
 	}
 	short a2;
-	if (unknownC420BD[((arg1 >> 8) & 0xFC)] == 0x100) {
+	if (unknownC41FFFSineTable[arg1Modified / 2 + 48] == 0x100) {
 		a2 = arg2;
 	} else {
-		a2 = unknownC4213F(unknownC420BD[((arg1 >> 8) & 0xFC)], arg2);
+		a2 = unknownC4213F(unknownC41FFFSineTable[arg1Modified / 2 + 48], arg2);
 	}
-	if ((((arg1 >> 8) & 0xFC) < 0x20) || (((arg1 >> 8) & 0xFC) >= 0x62)) {
+	if ((arg1Modified < 0x20) || (arg1Modified >= 0x62)) {
 		a2 = cast(short)-cast(int)a2;
 	}
-	if ((((arg1 >> 8) & 0xFC) >= 0x4C) && (((arg1 >> 8) & 0xFC) < 0x80)) {
+	if ((arg1Modified >= 0x42) && (arg1Modified < 0x80)) {
 		a = cast(short)-cast(int)a;
 	}
+	// a  =  sin(arg1) * arg2
+	// a2 = -cos(arg1) * arg2
 	return FixedPoint1616(a2, a);
 }
 
-/// $C4205D
-immutable ushort[48] unknownC4205D = [
+/// $C4205D and $C420BD
+immutable ushort[113] unknownC41FFFSineTable = [
 	0x0000,
 	0x0019,
 	0x0032,
@@ -400,11 +403,7 @@ immutable ushort[48] unknownC4205D = [
 	0x00F5,
 	0x00FB,
 	0x00FE,
-];
-
-/// $C420BD
-immutable ushort[65] unknownC420BD = [
-	0x0100,
+	0x0100, // Start of data used for cosine
 	0x00FE,
 	0x00FB,
 	0x00F5,
@@ -420,7 +419,7 @@ immutable ushort[65] unknownC420BD = [
 	0x004B,
 	0x0032,
 	0x0019,
-	0x0000,
+	0x0000, // End of data used for sine
 	0x0019,
 	0x0032,
 	0x004A,
@@ -2967,7 +2966,7 @@ ushort unknownC46ADB() {
 
 /// $C46B0A
 short unknownC46B0A(short arg1) {
-	entityUnknown1A86[currentEntitySlot] = cast(short)((arg1 + 0x1000) / 0x2000);
+	entityUnknown1A86[currentEntitySlot] = cast(short)(cast(ushort)(arg1 + 0x1000) / 0x2000);
 	return entityUnknown1A86[currentEntitySlot];
 }
 


### PR DESCRIPTION
- Fix a couple inverted conditions in ebMain, allows the in-game menus to open and avoids showing the gameover screen immediately
- Fix showTownMap to use findItemInInventory2 to search all characters inventories, instead of character 255 - pressing X doesn't crash the game
- Fix short comparisons: use -1 instead of 0xFFFF
- Add a missing -1 in two places in unknownC3E450 (wth is this function supposed to do? when do we animate text palettes based on the global framecount??)
- Fix unknownC41FFF to compute table indices correctly, and use a combined table for sine and cosine (previously it would index C4205D out of bounds)
- Perform unsigned division in unknownC46B0A, fixes the game crashing when Ness gets out of bed