### PR TITLE
Get status screen to show up (albeit badly)

### DIFF
--- a/source/earthbound/bank01.d
+++ b/source/earthbound/bank01.d
@@ -1475,7 +1475,7 @@ short charSelectPrompt(short arg1, short arg2, void function(short) arg3, short 
 	short x1E;
 	WinStat* x26 = getActiveWindowAddress();
 	uint x22 = x26.argument;
-	if (arg1 == 0) {
+	if (arg1 == 1) {
 		unknownC20A20(&unknown7E9C8A);
 		short x20 = (gameState.playerControlledPartyMemberCount == 1) ? Window.unknown33 : cast(short)(Window.unknown28 + gameState.playerControlledPartyMemberCount);
 		createWindowN(x20);
@@ -4910,13 +4910,13 @@ void unknownC1952F(short arg1) {
 	unknownC43D75(94, 3);
 	printNumber(partyCharacters[arg1].hp.current.integer);
 	unknownC43D75(114, 3);
-	printLetter(ebChar('\\'));
+	printLetter(ebChar('/'));
 	unknownC43D75(121, 3);
 	printNumber(partyCharacters[arg1].maxHP);
 	unknownC43D75(94, 4);
 	printNumber(partyCharacters[arg1].pp.current.integer);
 	unknownC43D75(114, 4);
-	printLetter(ebChar('\\'));
+	printLetter(ebChar('/'));
 	unknownC43D75(121, 4);
 	printNumber(partyCharacters[arg1].maxPP);
 	unknownC43D75(199, 0);
@@ -4937,7 +4937,7 @@ void unknownC1952F(short arg1) {
 	unknownC43D75(97, 5);
 	printNumber((partyCharacters[arg1].exp > 9_999_999) ? 9_999_999 : partyCharacters[arg1].exp);
 	unknownC43D75(10, 6);
-	printNumber(getRequiredEXP(arg1));
+	printNumber(getRequiredEXP(cast(short)(arg1 + 1)));
 	unknown7E5E71 = 0;
 	loop: for (short i = 0; i < 7; i++) {
 		ubyte x12 = partyCharacters[arg1].afflictions[i];
@@ -5879,7 +5879,7 @@ void unknownC1BB71() {
 		short x02 = 0;
 		createWindowN(Window.unknown2e);
 		for (short i = 0; i < 4; i++) {
-			unknownC115F4(cast(short)(i + 1), &psiCategories[i + 1][0], null);
+			unknownC115F4(cast(short)(i + 1), &psiCategories[i][0], null);
 		}
 		unknownC1180D(1, 0, 0);
 		while (true) {

--- a/source/earthbound/bank2F.d
+++ b/source/earthbound/bank2F.d
@@ -13804,7 +13804,20 @@ immutable ubyte[10][6] commandWindowText = [
 ];
 
 /// $EFA3B6
-immutable ubyte[0] statusWindowText;
+immutable ubyte[163] statusWindowText =
+	cast(ubyte[])[0x18, 0x05, 0x08, 0x00] ~ ebString!6("Level:") ~
+	cast(ubyte[])[0x18, 0x05, 0x2C, 0x03] ~ ebString!11("Hit Points:") ~
+	cast(ubyte[])[0x18, 0x05, 0x17, 0x04] ~ ebString!15("Psychic Points:") ~
+	cast(ubyte[])[0x18, 0x05, 0x0A, 0x05] ~ ebString!18("Experience Points:") ~
+	cast(ubyte[])[0x18, 0x05, 0x39, 0x06] ~ ebString!20("Exp. for next level.") ~
+	cast(ubyte[])[0x18, 0x05, 0x9C, 0x00] ~ ebString!8("Offense:") ~
+	cast(ubyte[])[0x18, 0x05, 0x9B, 0x01] ~ ebString!8("Defense:") ~
+	cast(ubyte[])[0x18, 0x05, 0xA4, 0x02] ~ ebString!6("Speed:") ~
+	cast(ubyte[])[0x18, 0x05, 0xAA, 0x03] ~ ebString!5("Guts:") ~
+	cast(ubyte[])[0x18, 0x05, 0x9F, 0x04] ~ ebString!9("Vitality:") ~
+	cast(ubyte[])[0x18, 0x05, 0xB6, 0x05] ~ ebString!3("IQ:") ~
+	cast(ubyte[])[0x18, 0x05, 0xAA, 0x06] ~ ebString!5("Luck:") ~
+	cast(ubyte[])[0x02];
 
 
 __gshared SpriteGrouping[464] spriteGroupingPointers = [


### PR DESCRIPTION
- Fix char select prompt error, which makes it not show it for just one char
- Change \ to / (I think this error is from ebsrc: 0x5f - 0x30 is /)
- Fix argument (missing +1) to getRequiredEXP
- Fix index to psiCategories (missing -1), fixes one crash when loading status screen
- Add statusWindowText (this is in ebsrc, so it should be OK to be here)