### PR TITLE
Enhance readability of map palette animation code

### DIFF
--- a/source/earthbound/bank01.d
+++ b/source/earthbound/bank01.d
@@ -3392,7 +3392,7 @@ void* cc1FE1(DisplayTextState* arg1, ushort arg2) {
 		ccArgumentStorage[ccArgumentGatheringLoopCounter++] = cast(ubyte)arg2;
 		return &cc1FE1;
 	}
-	unknownC4939C(ccArgumentStorage[0], ccArgumentStorage[1], cast(ubyte)arg2);
+	changeMapPalette(ccArgumentStorage[0], ccArgumentStorage[1], cast(ubyte)arg2);
 	return null;
 }
 

--- a/source/earthbound/globals.d
+++ b/source/earthbound/globals.d
@@ -910,6 +910,13 @@ __gshared ubyte[0x2000] unknown7EC000; /// $C000
 __gshared ubyte[64][64] unknown7EE000; /// $E000
 __gshared Unknown7EF000Stuff unknown7EF000; /// $F000
 __gshared ubyte[0x10000] unknown7F0000; /// $7F0000
+ref ushort[0x80] paletteAnimTargetPalette() { return (cast(ushort*)&unknown7F0000[0x7800])[0 .. 0x80]; }
+ref ushort[0x80] paletteAnimRedSlope() { return (cast(ushort*)&unknown7F0000[0x7900])[0 .. 0x80]; }
+ref ushort[0x80] paletteAnimGreenSlope() { return (cast(ushort*)&unknown7F0000[0x7A00])[0 .. 0x80]; }
+ref ushort[0x80] paletteAnimBlueSlope() { return (cast(ushort*)&unknown7F0000[0x7B00])[0 .. 0x80]; }
+ref ushort[0x80] paletteAnimRedAccum() { return (cast(ushort*)&unknown7F0000[0x7C00])[0 .. 0x80]; }
+ref ushort[0x80] paletteAnimGreenAccum() { return (cast(ushort*)&unknown7F0000[0x7D00])[0 .. 0x80]; }
+ref ushort[0x80] paletteAnimBlueAccum() { return (cast(ushort*)&unknown7F0000[0x7E00])[0 .. 0x80]; }
 __gshared ushort[0x3C00] tileArrangementBuffer; /// $7F8000
 __gshared const(ubyte[4][4])*[0x400] tileCollisionBuffer; /// $7FF800
 


### PR DESCRIPTION
Several functions and local variables were renamed for clarity. A few expressions were put into variables - I checked the ASM source to ensure that it was kept as consistent as possible.

Another big change is that these globals were given names:
```
$7F7800: paletteAnimTargetPalette
$7F7900: paletteAnimRedSlope
$7F7A00: paletteAnimGreenSlope
$7F7B00: paletteAnimBlueSlope
$7F7C00: paletteAnimRedAccum
$7F7D00: paletteAnimGreenAccum
$7F7E00: paletteAnimBlueAccum
```
This was done by creating functions with those names, which return `ref ushort[0x80]` referring to the correct portion of the unknown7F0000 array.