### PR TITLE
Rename symbols relating to sprite VRAM allocation, and fix bug where sprites never deallocate VRAM when going offscreen

### DIFF
--- a/source/earthbound/bank04.d
+++ b/source/earthbound/bank04.d
@@ -6642,7 +6642,7 @@ void unknownC4D8FA() {
 short unknownC4D989(short arg1) {
 	unknownC0927C();
 	clearSpriteTable();
-	allocSpriteMem(short.min, 0);
+	spriteVramTableOverwrite(short.min, 0);
 	initializeMiscObjectData();
 	unknown7E4A58 = 1;
 	unknown7E4A5A = 0;

--- a/source/earthbound/bank2F.d
+++ b/source/earthbound/bank2F.d
@@ -21699,7 +21699,7 @@ void debugMain() {
 	prepareForImmediateDMA();
 	unknownC0927C();
 	clearSpriteTable();
-	allocSpriteMem(short.min, 0);
+	spriteVramTableOverwrite(short.min, 0);
 	initializeMiscObjectData();
 	short x1C = debugViewCharacterSprite;
 	entityAllocationMinSlot = 0x17;

--- a/source/earthbound/globals.d
+++ b/source/earthbound/globals.d
@@ -422,7 +422,7 @@ __gshared short unknown7E467A; /// $(DOLLAR)467A
 __gshared short unknown7E467C; /// $(DOLLAR)467C
 __gshared SpriteMap[179] spriteTable7E467E; /// $(DOLLAR)467E
 
-__gshared ubyte[88] unknown7E4A00; /// $(DOLLAR)4A00
+__gshared ubyte[88] spriteVramTable; /// $(DOLLAR)4A00
 __gshared short unknown7E4A58; /// $(DOLLAR)4A58
 __gshared short unknown7E4A5A; /// $(DOLLAR)4A5A
 __gshared short overworldEnemyCount; /// $(DOLLAR)4A5C


### PR DESCRIPTION
This fixes the crash when walking to the meteor at the start of the game.