### PR TITLE
Fix Buzz Buzz beam

### DIFF
--- a/source/earthbound/bank00.d
+++ b/source/earthbound/bank00.d
@@ -4469,7 +4469,11 @@ void irqNMICommon() {
 	INIDISP = mirrorINIDISP;
 	MOSAIC = mirrorMOSAIC;
 	BG12NBA = mirrorBG12NBA;
-	WH2 = mirrorWH2;
+	// mirrorWH2 is loaded into Y for no reason here... and then immediately
+	// replaced with a constant which is written to WH2/3.
+	// This has the effect of disabling the 2nd window.
+	WH2 = 0xFF;
+	WH3 = 0x00;
 	for (short i = lastCompletedDMAIndex; i != dmaQueueIndex; i++) {
 		handleVRAMDMA(dmaTable[dmaQueue[i].mode].unknown0, dmaTable[dmaQueue[i].mode].unknown1, dmaQueue[i].source, dmaQueue[i].size, dmaQueue[i].destination, dmaTable[dmaQueue[i].mode].unknown2);
 	}
@@ -7453,7 +7457,7 @@ void unknownC0AA23(short, ref const(ubyte)* arg2) {
 
 /// $C0AA3F
 void unknownC0AA3F(short arg1, ref const(ubyte)* arg2) {
-	short x = (--arg1 == 0) ? 0x33 : 0xB3;
+	short x = (--arg1 != 0) ? 0x33 : 0xB3;
 	unknown7E9E37 = cast(ubyte)movementDataRead8(arg2);
 	actionScriptVar94 = arg2;
 	unknown7E9E38 = cast(ubyte)movementDataRead8(arg2);

--- a/source/earthbound/globals.d
+++ b/source/earthbound/globals.d
@@ -23,8 +23,7 @@ __gshared ubyte mirrorBG3SC; /// $(DOLLAR)0013
 __gshared ubyte mirrorBG4SC; /// $(DOLLAR)0014
 __gshared ubyte mirrorBG12NBA; /// $(DOLLAR)0015
 __gshared ubyte mirrorBG34NBA; /// $(DOLLAR)0016
-__gshared ubyte mirrorWH2; /// $(DOLLAR)0017
-__gshared ushort unknown7E0018; /// $(DOLLAR)0018
+__gshared ushort mirrorWH2; /// $(DOLLAR)0017
 __gshared ubyte mirrorTM; /// $(DOLLAR)001A
 __gshared ubyte mirrorTD; /// $(DOLLAR)001B
 


### PR DESCRIPTION
There were two issues here:
1. Window 2 (WH2/3) was being enabled due to actually using its mirrored value (unused) instead of disabling it from the NMI handler
2. Due to an inverted condition check, colour math was subtracting instead of adding, hence the blue colour instead of yellow

Fixes #128 