### PR TITLE
Clear `input.step` when processing a frame

### DIFF
--- a/sdl/source/main.d
+++ b/sdl/source/main.d
@@ -239,6 +239,7 @@ void main(string[] args) {
 		}
 
 		if (!paused || input.step) {
+			input.step = false;
 			Throwable t = game.call(Fiber.Rethrow.no);
 			if(t) {
 				throw t;


### PR DESCRIPTION
Currently, the step feature doesn't work as I expect - when stepping, the game processes frames while the key is held down, meaning that in order to step forward only one frame, you must press the key for less than 2 frames. I expect that when pressing the key, it should step one frame, and avoid stepping until the key is pressed again (or key repeat activates).