### PR TITLE
Fix a few things relating to battles

### DIFF
--- a/source/earthbound/bank01.d
+++ b/source/earthbound/bank01.d
@@ -1208,39 +1208,59 @@ short getNextTargetRight(short row, short position, short action) {
 
 /// $C12070
 short getNextTargetLeft(short row, short position, short action) {
-	ubyte* x04;
-	short x;
-	if (row == Row.front) {
-		x = numBattlersInFrontRow;
-		x04 = &battlerFrontRowXPositions[x - 1];
-	} else {
-		x = numBattlersInBackRow;
-		x04 = &battlerBackRowXPositions[x - 1];
-	}
-	for (short i = cast(short)(x - 1); i + 1 != 0; i--) {
-		if ((x04--)[0] < position) {
-			if (getTargettingAllowed(row, i, action) != 0) {
-				return i;
+	version(noUndefinedBehaviour) {
+		short numBattlersInRow;
+		ubyte[] battlerRowXPositions;
+		if (row == Row.front) {
+			numBattlersInRow = numBattlersInFrontRow;
+			battlerRowXPositions = battlerFrontRowXPositions;
+		} else {
+			numBattlersInRow = numBattlersInBackRow;
+			battlerRowXPositions = battlerBackRowXPositions;
+		}
+		for (short i = cast(short)(numBattlersInRow - 1); i >= 0; i--) {
+			if (battlerRowXPositions[i] < position) {
+				if (getTargettingAllowed(row, i, action) != 0) {
+					return i;
+				}
 			}
 		}
+		return -1;
+	} else {
+		ubyte* x04;
+		short numBattlersInRow;
+		if (row == Row.front) {
+			numBattlersInRow = numBattlersInFrontRow;
+			x04 = &battlerFrontRowXPositions[numBattlersInRow - 1];
+		} else {
+			numBattlersInRow = numBattlersInBackRow;
+			x04 = &battlerBackRowXPositions[numBattlersInRow - 1];
+		}
+		for (short i = cast(short)(numBattlersInRow - 1); i + 1 != 0; i--) {
+			if ((x04--)[0] < position) {
+				if (getTargettingAllowed(row, i, action) != 0) {
+					return i;
+				}
+			}
+		}
+		return -1;
 	}
-	return -1;
 }
 
 /// $C120D6
-void printTargetName(short arg1, short arg2) {
+void printTargetName(short row, short target) {
 	setInstantPrinting();
 	createWindowN(Window.unknown31);
 	printString(battleToText.length, &battleToText[0]);
-	if (arg2 != -1) {
-		unknownC23E8A(cast(short)(arg1 * numBattlersInFrontRow + arg2 + 1));
+	if (target != -1) {
+		unknownC23E8A(cast(short)(row * numBattlersInFrontRow + target + 1));
 		printBattlerArticle(0);
 		printString(0xFF, getBattleAttackerName());
-		ubyte* x12 = (arg1 != 0) ? &battlersTable[frontRowBattlers[arg2]].afflictions[0] : &battlersTable[backRowBattlers[arg2]].afflictions[0];
+		ubyte* x12 = (row != Row.front) ? &battlersTable[backRowBattlers[target]].afflictions[0] : &battlersTable[frontRowBattlers[target]].afflictions[0];
 		moveCurrentTextCursor(0x11, 0);
 		unknownC43F77(unknownC223D9(x12, 0));
 	} else {
-		printString(13, (arg1 != 0) ? &battleBackRowText[0] : &battleFrontRowText[0]);
+		printString(13, (row != Row.front) ? &battleBackRowText[0] : &battleFrontRowText[0]);
 	}
 	clearInstantPrinting();
 }
@@ -1267,7 +1287,7 @@ short pickTargetSingle(short arg1, short action) {
 		windowTick();
 		NoButtonPressed:
 		windowTickMinimal();
-		if ((((padPress[0] & Pad.up) == 0) || (row != 0) || (numBattlersInBackRow == 0)) && (((padPress[0] & Pad.down) == 0) || (row != 1) || (numBattlersInFrontRow == 0))) {
+		if ((((padPress[0] & Pad.up) == 0) || (row != Row.front) || (numBattlersInBackRow == 0)) && (((padPress[0] & Pad.down) == 0) || (row != Row.back) || (numBattlersInFrontRow == 0))) {
 			cursorSFX = Sfx.cursor2;
 			if ((padPress[0] & Pad.left) != 0) {
 				tmpRow = row;

--- a/source/earthbound/bank02.d
+++ b/source/earthbound/bank02.d
@@ -1913,9 +1913,9 @@ void unknownC23E8A(short arg1) {
 	short x02;
 	memset(&unknown7EA9B9[0], 0, unknown7EA9B9.length);
 	if (arg1 > numBattlersInFrontRow) {
-		x02 = frontRowBattlers[arg1 - numBattlersInFrontRow - 1];
+		x02 = backRowBattlers[arg1 - numBattlersInFrontRow - 1];
 	} else {
-		x02 = backRowBattlers[arg1 - 1];
+		x02 = frontRowBattlers[arg1 - 1];
 	}
 	ubyte* x12 = copyEnemyName(&enemyConfigurationTable[battlersTable[x02].id].name[0], &unknown7EA9B9[0], unknown7EA9B9.length);
 	if ((battlersTable[x02].suffixLetter != 1) || (getNextAvailableEnemyLetter(battlersTable[x02].originalID) != 2)) {
@@ -2138,20 +2138,20 @@ void removeUsedItem() {
 short unknownC24434(Battler* arg1) {
 	arg1.currentTarget = cast(ubyte)(randLimit(cast(short)(numBattlersInFrontRow + numBattlersInBackRow)) + 1);
 	if (arg1.currentTarget > numBattlersInFrontRow) {
-		return frontRowBattlers[arg1.currentTarget - numBattlersInFrontRow - 1];
+		return backRowBattlers[arg1.currentTarget - numBattlersInFrontRow - 1];
 	}
-	return backRowBattlers[arg1.currentTarget - 1];
+	return frontRowBattlers[arg1.currentTarget - 1];
 }
 
 /// $C24477
 void chooseTarget(Battler* arg1) {
 	for (short i = 0; i < numBattlersInFrontRow; i++) {
-		if (checkIfValidTarget(backRowBattlers[i]) == 0) {
+		if (checkIfValidTarget(frontRowBattlers[i]) == 0) {
 			goto Unknown4;
 		}
 	}
 	for (short i = 0; i < numBattlersInBackRow; i++) {
-		if (checkIfValidTarget(frontRowBattlers[i]) == 0) {
+		if (checkIfValidTarget(backRowBattlers[i]) == 0) {
 			goto Unknown4;
 		}
 	}
@@ -2209,13 +2209,14 @@ void chooseTarget(Battler* arg1) {
 						}
 					}
 				} else {
-					arg1.currentTarget = (rand() & 7) + 1;
-					if (checkIfValidTarget(arg1.currentTarget - 1) != 0) {
-						return;
+					while (true) {
+						arg1.currentTarget = (rand() & 7) + 1;
+						if (checkIfValidTarget(arg1.currentTarget - 1) != 0) {
+							return;
+						}
 					}
 				}
 			}
-			break;
 		case ActionTarget.row:
 			arg1.actionTargetting |= Targetted.row;
 			if (arg1.side == BattleSide.foes) {
@@ -2253,9 +2254,9 @@ void resolveTargetting(Battler* battler) {
 			break;
 		case Targetted.enemies | Targetted.single:
 			if (battler.currentTarget > numBattlersInFrontRow) {
-				targetBattler(frontRowBattlers[battler.currentTarget - numBattlersInFrontRow - 1]);
+				targetBattler(backRowBattlers[battler.currentTarget - numBattlersInFrontRow - 1]);
 			} else {
-				targetBattler(backRowBattlers[battler.currentTarget - 1]);
+				targetBattler(frontRowBattlers[battler.currentTarget - 1]);
 			}
 			if (battler.currentAction == BattleActions.psiHealingOmega) {
 				for (short i = 8; i < battlersTable.length; i++) {
@@ -8248,8 +8249,8 @@ void drawBattleSprites() {
 /// $C2F917
 void unknownC2F917() {
 	short x0E;
-	numBattlersInBackRow = 0;
 	numBattlersInFrontRow = 0;
+	numBattlersInBackRow = 0;
 	for (short i = 8; i < battlersTable.length; i++) {
 		if (battlersTable[i].consciousness == 0) {
 			continue;
@@ -8279,7 +8280,7 @@ void unknownC2F917() {
 			if (battlersTable[j].side != BattleSide.foes) {
 				continue;
 			}
-			if (battlersTable[j].row != 0) {
+			if (battlersTable[j].row != Row.front) {
 				continue;
 			}
 			if ((battlersTable[j].spriteX > x10) && (battlersTable[j].spriteX <= x04)) {
@@ -8287,7 +8288,7 @@ void unknownC2F917() {
 				x04 = battlersTable[j].spriteX;
 			}
 		}
-		backRowBattlers[i] = cast(ubyte)(x0E);
+		frontRowBattlers[i] = cast(ubyte)(x0E);
 		battlerFrontRowXPositions[i] = cast(ubyte)(x04 / 8);
 		battlerFrontRowYPositions[i] = cast(ubyte)(18 - getBattleSpriteHeight(battlersTable[x0E].sprite));
 		x10 = x04;
@@ -8305,7 +8306,7 @@ void unknownC2F917() {
 			if (battlersTable[j].side != BattleSide.foes) {
 				continue;
 			}
-			if (battlersTable[j].row == 0) {
+			if (battlersTable[j].row == Row.front) {
 				continue;
 			}
 			if ((battlersTable[j].spriteX > x10) && (battlersTable[j].spriteX <= x04)) {
@@ -8313,7 +8314,7 @@ void unknownC2F917() {
 				x04 = battlersTable[j].spriteX;
 			}
 		}
-		frontRowBattlers[i] = cast(ubyte)(x0E);
+		backRowBattlers[i] = cast(ubyte)(x0E);
 		battlerBackRowXPositions[i] = cast(ubyte)(x04 / 8);
 		battlerBackRowYPositions[i] = cast(ubyte)(18 - getBattleSpriteHeight(battlersTable[x0E].sprite));
 		x10 = x04;

--- a/source/earthbound/bank03.d
+++ b/source/earthbound/bank03.d
@@ -545,7 +545,7 @@ void printBattlerArticle(short target) {
 			printAttackerArticle = 0;
 			return;
 		}
-		if (printAttackerArticle == 0) {
+		if (printAttackerArticle != 0) {
 			return;
 		}
 		enemyID = attackerEnemyID;
@@ -554,7 +554,7 @@ void printBattlerArticle(short target) {
 			printTargetArticle = 0;
 			return;
 		}
-		if (printTargetArticle == 0) {
+		if (printTargetArticle != 0) {
 			return;
 		}
 		enemyID = targetEnemyID;

--- a/source/earthbound/bank04.d
+++ b/source/earthbound/bank04.d
@@ -1312,11 +1312,11 @@ void rowEnemyFlashingOff() {
 	if (unknown7E89CE == -1) {
 		return;
 	}
-	for (short i = 0; i < (unknown7E89CE != 0) ? numBattlersInBackRow : numBattlersInFrontRow; i++) {
-		if (unknown7E89CE != 0) {
-			battlersTable[frontRowBattlers[i]].isFlashing = 0;
-		} else {
+	for (short i = 0; i < (unknown7E89CE != Row.front) ? numBattlersInBackRow : numBattlersInFrontRow; i++) {
+		if (unknown7E89CE != Row.front) {
 			battlersTable[backRowBattlers[i]].isFlashing = 0;
+		} else {
+			battlersTable[frontRowBattlers[i]].isFlashing = 0;
 		}
 	}
 	enemyTargettingFlashing = 0;
@@ -1330,11 +1330,11 @@ void rowEnemyFlashingOn(short arg1) {
 		rowEnemyFlashingOff();
 	}
 	unknown7E89CE = arg1;
-	for (short i = 0; i < (unknown7E89CE != 0) ? numBattlersInBackRow : numBattlersInFrontRow; i++) {
-		if (unknown7E89CE != 0) {
-			battlersTable[frontRowBattlers[i]].isFlashing = 1;
-		} else {
+	for (short i = 0; i < (unknown7E89CE != Row.front) ? numBattlersInBackRow : numBattlersInFrontRow; i++) {
+		if (unknown7E89CE != Row.front) {
 			battlersTable[backRowBattlers[i]].isFlashing = 1;
+		} else {
+			battlersTable[frontRowBattlers[i]].isFlashing = 1;
 		}
 	}
 	enemyTargettingFlashing = 1;

--- a/source/earthbound/bank2F.d
+++ b/source/earthbound/bank2F.d
@@ -23,10 +23,10 @@ void singleEnemyFlashingOff() {
 	if (unknown7E89D0 == -1) {
 		return;
 	}
-	if (unknown7E89D2 != 0) {
-		battlersTable[frontRowBattlers[unknown7E89D0]].isFlashing = 0;
-	} else {
+	if (unknown7E89D2 != Row.front) {
 		battlersTable[backRowBattlers[unknown7E89D0]].isFlashing = 0;
+	} else {
+		battlersTable[frontRowBattlers[unknown7E89D0]].isFlashing = 0;
 	}
 	enemyTargettingFlashing = 0;
 	unknown7E89D0 = -1;
@@ -40,10 +40,10 @@ void singleEnemyFlashingOn(short arg1, short arg2) {
 	}
 	unknown7E89D0 = arg2;
 	unknown7E89D2 = arg1;
-	if (arg1 != 0) {
-		battlersTable[frontRowBattlers[unknown7E89D0]].isFlashing = 1;
-	} else {
+	if (arg1 != Row.front) {
 		battlersTable[backRowBattlers[unknown7E89D0]].isFlashing = 1;
+	} else {
+		battlersTable[frontRowBattlers[unknown7E89D0]].isFlashing = 1;
 	}
 	enemyTargettingFlashing = 1;
 	redrawAllWindows = 1;

--- a/source/earthbound/globals.d
+++ b/source/earthbound/globals.d
@@ -767,8 +767,8 @@ __gshared ubyte[8] battlerFrontRowXPositions; /// $(DOLLAR)AD5A
 __gshared ubyte[8] battlerFrontRowYPositions; /// $(DOLLAR)AD62
 __gshared ubyte[8] battlerBackRowXPositions; /// $(DOLLAR)AD6A
 __gshared ubyte[8] battlerBackRowYPositions; /// $(DOLLAR)AD72
-__gshared ubyte[8] backRowBattlers; /// $(DOLLAR)AD7A
-__gshared ubyte[8] frontRowBattlers; /// $(DOLLAR)AD82
+__gshared ubyte[8] frontRowBattlers; /// $(DOLLAR)AD7A
+__gshared ubyte[8] backRowBattlers; /// $(DOLLAR)AD82
 __gshared short currentLayerConfig; /// $(DOLLAR)AD8A
 __gshared short verticalShakeDuration; /// $(DOLLAR)AD8C
 __gshared short verticalShakeHoldDuration; /// $(DOLLAR)AD8E


### PR DESCRIPTION
- Avoid illegal array access in getNextTargetLeft - fixes crashing when pressing left while selecting enemy to attack
- Fix issues relating to back/front row being swapped - the global variable addresses are correct here now but are wrong in ebsrc
- Fix incorrect comparison resulting in enemy articles ("the") not being printed