### PR TITLE
Fix generarting earthbound.planet

### DIFF
--- a/source/earthbound/external/dataloader.d
+++ b/source/earthbound/external/dataloader.d
@@ -72,6 +72,7 @@ void extractExtraAssets(scope AddFileFunction addFile, scope ProgressUpdateFunct
     buildNSPCFiles(rom, addFile, song4);
     ubyte[][0x80] sfx;
     static __gshared uint counter;
+/*
     foreach (i, ref data; sfx[].parallel) {
         data = dumpSoundEffect(song4[], cast(ubyte)i);
         reportProgress(Progress("Extracting sound effects", ++counter, 127));
@@ -79,6 +80,7 @@ void extractExtraAssets(scope AddFileFunction addFile, scope ProgressUpdateFunct
     foreach (idx, sound; sfx) {
         addFile(format!"sfx/%03d.wav"(idx), sound);
     }
+*/
 
     const extractDoc = "extract.yaml";
     const extractInfo = fromFile!(ExtractInfo, YAML)(extractDoc);


### PR DESCRIPTION
I'm very confused about why it seems the rom is modified when extraction fails but with a clean rom this makes extraction work and gets in game at least...
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f45440d0-0f40-4993-92cb-976fc28a4c9c" />
I am not sure why it randomly throwed text errors before

Fixes #172 altough this is probably nothing but a stop gap fix